### PR TITLE
Json schema tweaks and test cases

### DIFF
--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-fileshare-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-fileshare-service-subschema.json
@@ -21,18 +21,19 @@
                     "type": "object",
                     "properties": {
                         "storageAccountName": {
+                            "description": "Azure storage account name (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         },
                         "storageFileShareName": {
+                            "description": "Azure storage file share name.",
                             "type": "string"
                         },
                         "storageAccountKey": {
+                            "description": "Azure storage account key (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         }
                     },
                     "required": [
-                        "storageAccountKey",
-                        "storageAccountName",
                         "storageFileShareName"
                     ]
                 }

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
@@ -20,18 +20,24 @@
                 {
                     "properties": {
                         "subscription": {
+                            "description": "Azure subscription id (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         },
                         "accessToken": {
+                            "description": "Azure access token (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         },
                         "resourceGroup": {
+                            "description": "The name of the resource group to place the deployment in (typically provided in the global config in order to omit from source control).",
                             "type": "string"
                         },
                         "deploymentName": {
+                            "$comment": "TODO: provide templating strings to augment names via experimentId/trialId, for instance.",
+                            "description": "Name of the deployment to create for the experiment resources.",
                             "type": "string"
                         },
                         "deploymentTemplatePath": {
+                            "description": "Path to an ARM template file.",
                             "type": "string",
                             "pattern": "[.]json[c]?$"
                         },

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
@@ -57,12 +57,8 @@
                         }
                     },
                     "required": [
-                        "subscription",
-                        "accessToken",
-                        "resourceGroup",
                         "deploymentName",
-                        "deploymentTemplatePath",
-                        "deploymentTemplateParameters"
+                        "deploymentTemplatePath"
                     ]
                 }
             ],

--- a/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
+++ b/mlos_bench/mlos_bench/config/schemas/services/remote/azure/azure-vm-service-subschema.json
@@ -52,7 +52,8 @@
                                     "boolean",
                                     "null"
                                 ]
-                            }
+                            },
+                            "minProperties": 1
                         }
                     },
                     "required": [

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_fileshare_service-config-missing.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_fileshare_service-config-missing.jsonc
@@ -2,7 +2,7 @@
     "class": "mlos_bench.services.remote.azure.AzureFileShareService",
     "config": {
         "storageAccountName": "storage-account-name",
-        "storageFileShareName": "file-share-name",
-        //"storageAccountKey": "required param missing"
+        //"storageFileShareName": "required param missing",
+        "storageAccountKey": "required param missing"
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-array.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-array.jsonc
@@ -1,0 +1,14 @@
+{
+    "class": "mlos_bench.services.remote.azure.AzureVMService",
+    "config": {
+        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
+        "subscription": "subscription-id",
+        // "accessToken": "access-token-blob",
+
+        "resourceGroup": "rg",
+        "deploymentName": "deployment",
+        "deploymentTemplateParameters": {
+            "array": [ "invalid" ]
+        }
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-object.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-arm-params-bad-type-object.jsonc
@@ -1,0 +1,14 @@
+{
+    "class": "mlos_bench.services.remote.azure.AzureVMService",
+    "config": {
+        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
+        "subscription": "subscription-id",
+        // "accessToken": "access-token-blob",
+
+        "resourceGroup": "rg",
+        "deploymentName": "deployment",
+        "deploymentTemplateParameters": {
+            "object": { "invalid": "type" }
+        }
+    }
+}

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-empty-arm-params.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-empty-arm-params.jsonc
@@ -7,7 +7,7 @@
         "deploymentName": "deployment",
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "deploymentTemplateParameters": {
-            "param": "value"
+            // "param": "value" // <-- need at least one parameter
         }
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-missing.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/bad/invalid/azure_vm_service-config-missing.jsonc
@@ -3,9 +3,9 @@
     "config": {
         "deploymentTemplatePath": "some/path/to/deployment/template.jsonc",
         "subscription": "subscription-id",
-        // "accessToken": "access-token-blob",
+        "accessToken": "access-token-blob",
 
-        "resourceGroup": "rg",
-        "deploymentName": "deployment"
+        "resourceGroup": "rg"
+        //"deploymentName": "deployment"    // <-- missing
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/full/azure_vm_service-full.jsonc
@@ -19,7 +19,7 @@
             "virtualNetworkName": "vnet",
             "subnetName": "subnet",
             "networkSecurityGroupName": "nsg",
-            "ubuntuOSVersion": "18.04-LTS",
+            "ubuntuOSVersion": "18.04-LTS"
         },
 
         "pollInterval": 1,

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_fileshare_service-partial.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_fileshare_service-partial.jsonc
@@ -1,8 +1,8 @@
 {
     "class": "mlos_bench.services.remote.azure.AzureFileShareService",
     "config": {
-        "storageAccountName": "storage-account-name",
-        "storageFileShareName": "file-share-name",
-        "storageAccountKey": "storage-account-key-blob"
+        //"storageAccountName": "storage-account-name",
+        //"storageAccountKey": "storage-account-key-blob",
+        "storageFileShareName": "file-share-name"
     }
 }

--- a/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial-no-arm-params.jsonc
+++ b/mlos_bench/mlos_bench/tests/config/schemas/services/test-cases/good/partial/azure_vm_service-partial-no-arm-params.jsonc
@@ -1,0 +1,7 @@
+{
+    "class": "mlos_bench.services.remote.azure.AzureVMService",
+    "config": {
+        "deploymentName": "deployment",
+        "deploymentTemplatePath": "some/path/to/deployment/template.jsonc"
+    }
+}


### PR DESCRIPTION
- reduce what's required in a json schema for azure (since some of those are permissions oriented and we want to keep those in the global configs so no need to require dummy values)
- add descriptions on some of the fields
- add test cases for some of the new schema changes